### PR TITLE
Update package-lock, raw-loader should be dependency not dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8977,8 +8977,7 @@
     "raw-loader": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-      "dev": true
+      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao="
     },
     "read-cache": {
       "version": "1.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
       },
       {
         test: /\.svg$/,
-        use: 'raw-loader'
+        use: { loader: 'raw-loader' }
       }
     ]
   },


### PR DESCRIPTION
## Description
Raw-loader was marked as dev dependency in package-lock, not picked-up by samson while installing packages 

## CCs
@zendesk/apps-migration

## Risks
* [low] update package-lock.json

